### PR TITLE
Fix diagnostics warning

### DIFF
--- a/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.hpp
+++ b/phidgets_spatial/include/phidgets_spatial/spatial_ros_i.hpp
@@ -91,6 +91,7 @@ class SpatialRosI final : public rclcpp::Node
     int64_t cb_delta_epsilon_ns_{0};
 
     void calibrate();
+    rclcpp::TimerBase::SharedPtr cal_timer_;
 
     void calibrateService(
         const std::shared_ptr<std_srvs::srv::Empty::Request> req,

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -273,11 +273,6 @@ SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
         cal_publisher_ = this->create_publisher<std_msgs::msg::Bool>(
             "imu/is_calibrated", rclcpp::SystemDefaultsQoS().transient_local());
 
-        cal_timer_ = this->create_wall_timer(std::chrono::seconds(1), [this]() -> void {
-            cal_timer_->cancel();
-            calibrate();
-        });
-
         // set the hardware id for diagnostics
         diag_updater_.setHardwareIDf("phidget_spatial-%d", spatial_->getSerialNumber());
 
@@ -352,6 +347,11 @@ SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
 
     diag_updater_.add("IMU Driver Status", this, &SpatialRosI::phidgetsDiagnostics);
     diag_updater_.add("Connection Status", this, &SpatialRosI::checkConnection);
+
+    cal_timer_ = this->create_wall_timer(std::chrono::seconds(0), [this]() -> void {
+        cal_timer_->cancel();
+        calibrate();
+    });
 }
 
 void SpatialRosI::calibrate()

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -657,12 +657,7 @@ void SpatialRosI::errorCallback(Phidget_ErrorEventCode error_code, const char *e
 
 void SpatialRosI::phidgetsDiagnostics(diagnostic_updater::DiagnosticStatusWrapper &stat)
 {
-    if (error_number_ == 4)
-    {
-        stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "The Phidget reports a warning.");
-        stat.add("Error Number", error_number_);
-        stat.add("Error message", "An error occurred when trying to dispatch an event.");
-    } else if (error_number_ != 0)
+    if (error_number_ != 0)
     {
         stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "The Phidget reports error.");
         stat.add("Error Number", error_number_);

--- a/phidgets_spatial/src/spatial_ros_i.cpp
+++ b/phidgets_spatial/src/spatial_ros_i.cpp
@@ -273,7 +273,10 @@ SpatialRosI::SpatialRosI(const rclcpp::NodeOptions &options)
         cal_publisher_ = this->create_publisher<std_msgs::msg::Bool>(
             "imu/is_calibrated", rclcpp::SystemDefaultsQoS().transient_local());
 
-        calibrate();
+        cal_timer_ = this->create_wall_timer(std::chrono::seconds(1), [this]() -> void {
+            cal_timer_->cancel();
+            calibrate();
+        });
 
         // set the hardware id for diagnostics
         diag_updater_.setHardwareIDf("phidget_spatial-%d", spatial_->getSerialNumber());


### PR DESCRIPTION
This PR is meant to fix the following diagnostics warning sent constantly by the `/phidgets_spatial` node.

```
- level: "\x01"
  name: 'phidgets_spatial: IMU Driver Status'
  message: The Phidget reports a warning.
  hardware_id: phidget_spatial-722643
  values:
  - key: Error Number
    value: '4'
  - key: Error message
    value: An error occurred when trying to dispatch an event.
```

The issue is that during calibration an [EPHIDGET_INTERRUPTED (0x04)](https://www.phidgets.com/?view=api) error occurs and does not get reset since the `errorCallback` which sets the `error_number_` and `error_msg_` is not polled to clear the error. but read on every new error as a callback.

```
[component_container-1] [INFO] [phidget_container]: Load Library: /home/ubuntu/ros2-service-robot/workspace/install/phidgets_spatial/lib/libphidgets_spatial.so
[component_container-1] [INFO] [phidget_container]: Found class: rclcpp_components::NodeFactoryTemplate<phidgets::SpatialRosI>
[component_container-1] [INFO] [phidget_container]: Instantiate class: rclcpp_components::NodeFactoryTemplate<phidgets::SpatialRosI>
[component_container-1] [INFO] [phidgets_spatial]: Starting Phidgets Spatial
[component_container-1] [INFO] [phidgets_spatial]: Connecting to Phidgets Spatial serial -1, hub port 0 ...
[component_container-1] [INFO] [phidgets_spatial]: Connected to serial 722643
[component_container-1] [INFO] [phidgets_spatial]: Calibrating IMU, this takes around 2 seconds to finish. Make sure that the device is not moved during this time.
[component_container-1] [ERROR] [phidgets_spatial]: Phidget Spatial: Spatial Ch:0 -> MOT0110 S/N:722643: Event queue is full; dropping event(s). Make sure data event handlers are fast and non-blocking, or reduce data rate. (4)
[component_container-1] [INFO] [phidgets_spatial]: Calibrating IMU done.
```

This PR solves the above issue by delaying the calibration by 1 second. The calibration is blocking for 2 serconds, 1 second seems like a reasonable time to wait for the imu's event queue to clear.

The special case for handling 0x04 error as a warning is also removed.